### PR TITLE
Package and export sourcemaps and types

### DIFF
--- a/analysis.md
+++ b/analysis.md
@@ -1,0 +1,86 @@
+
+## Package.json and Build Setup Analysis
+
+### Current Build Setup and Scripts
+- The project uses **esbuild** for bundling the TypeScript code into a single JavaScript file
+- Build command: `esbuild src/index.ts --bundle --platform=node --target=node18 --outfile=dist/index.js`
+- The build creates a single bundled file at `dist/index.js` with no sourcemaps
+- TypeScript is used for development but not for generating declaration files
+
+### Current Package Exports
+- `main`: Points to `dist/index.js` (the bundled output)
+- `bin`: Exposes `lsp-cli` as a CLI command
+- No `exports` field for modern module resolution
+- No `types` field for TypeScript declarations
+
+### Sourcemaps Status
+- **NOT currently being generated** - the esbuild command doesn't include sourcemap flags
+
+### TypeScript Configuration
+- `tsconfig.json` is configured for CommonJS output
+- `outDir` is set to `./dist` but TypeScript compilation isn't used in the build
+- Currently only used for type checking (`npm run typecheck`)
+
+### What Needs to be Added
+The package appears to be both a CLI tool and a library (exports multiple classes and types). To properly export sourcemaps and types for consumers:
+
+1. **Generate TypeScript declaration files** (.d.ts files)
+2. **Enable sourcemap generation** in the build process
+3. **Update package.json exports** to include:
+   - Types field pointing to declaration files
+   - Proper exports field for module resolution
+   - Include sourcemap files in the package
+
+4. **Exported APIs that should be available to consumers:**
+   - `LanguageClient` class
+   - `ServerManager` class
+   - `Logger` class
+   - Various TypeScript interfaces and types
+   - Utility functions
+
+## Exported APIs and Types Analysis
+
+### Currently Exported from src/index.ts
+- Nothing is currently exported from `src/index.ts`. It's purely a CLI entry point that uses Commander.js to handle command-line arguments and execute the analysis.
+
+### Types and Interfaces in src/types.ts
+These types should be available to library consumers:
+- `SupportedLanguage` - Type union for supported programming languages
+- `Position` - Line and character position in a file
+- `Range` - Start and end positions defining a range
+- `Supertype` - Type information including name and type arguments
+- `SymbolInfo` - Core type containing symbol information extracted from code
+- `ToolchainCheckResult` - Result of toolchain availability check
+- `ProjectFileCheckResult` - Result of project file detection
+- `ServerConfig` - Configuration for LSP servers
+- `LoggerOptions` - Options for the Logger class
+
+### Classes and Functions That Could Be Useful as a Library
+The following components would be valuable for programmatic use:
+
+**Core Classes:**
+- `LanguageClient` - Main class for interacting with LSP servers
+- `ServerManager` - Manages LSP server installation and lifecycle
+- `Logger` - Logging utility with structured output
+
+**Utility Functions:**
+- `checkToolchain()` - Verify if language toolchain is installed
+- `checkProjectFiles()` - Check for project configuration files
+- `getAllFiles()` - Recursively find files by extension
+- `downloadFile()` - Download files with redirect handling
+- `extractArchive()` - Extract zip/tar archives
+
+### Current Usage Pattern
+The codebase is currently **purely CLI-focused**. There's no existing library usage pattern. The main workflow is:
+1. CLI parses arguments
+2. Checks toolchain and project files
+3. Ensures LSP server is installed
+4. Creates LanguageClient instance
+5. Analyzes directory and outputs JSON
+
+To make this available as a library, the core functionality would need to be refactored to separate CLI concerns from the programmatic API, allowing consumers to:
+- Programmatically analyze codebases
+- Customize logging behavior
+- Handle results in-memory instead of just file output
+- Integrate LSP analysis into other tools
+EOF < /dev/null

--- a/package.json
+++ b/package.json
@@ -2,10 +2,30 @@
     "name": "@mariozechner/lsp-cli",
     "version": "0.1.1",
     "description": "CLI tool to extract types from codebases using LSP servers",
-    "main": "dist/index.js",
+    "main": "dist/lib.js",
+    "types": "dist/lib.d.ts",
     "bin": {
-        "lsp-cli": "dist/index.js"
+        "lsp-cli": "dist/cli.js"
     },
+    "exports": {
+        ".": {
+            "types": "./dist/lib.d.ts",
+            "import": "./dist/lib.js",
+            "require": "./dist/lib.js"
+        },
+        "./cli": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/cli.js",
+            "require": "./dist/cli.js"
+        }
+    },
+    "files": [
+        "dist/**/*.js",
+        "dist/**/*.d.ts",
+        "dist/**/*.js.map",
+        "dist/**/*.d.ts.map",
+        "dist/llms.md"
+    ],
     "scripts": {
         "start": "tsx src/index.ts",
         "build": "rm -rf dist && mkdir -p dist && tsc && esbuild src/index.ts --bundle --platform=node --target=node18 --outfile=dist/cli.js --sourcemap --banner:js='#!/usr/bin/env node' && chmod +x dist/cli.js && cp llms.md dist/",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "scripts": {
         "start": "tsx src/index.ts",
-        "build": "esbuild src/index.ts --bundle --platform=node --target=node18 --outfile=dist/index.js --banner:js='#!/usr/bin/env node' && chmod +x dist/index.js && cp llms.md dist/",
+        "build": "rm -rf dist && mkdir -p dist && tsc && esbuild src/index.ts --bundle --platform=node --target=node18 --outfile=dist/cli.js --sourcemap --banner:js='#!/usr/bin/env node' && chmod +x dist/cli.js && cp llms.md dist/",
         "typecheck": "tsc --noEmit",
         "lint": "biome check --write . --error-on-warnings",
         "format": "biome format --write .",

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,0 +1,17 @@
+// Library entry point - exports core functionality for programmatic use
+
+// Export core classes
+export { LanguageClient } from './language-client.js';
+export { Logger } from './logger.js';
+export { ServerManager } from './server-manager.js';
+// Export all types
+export * from './types.js';
+
+// Export utility functions
+export {
+    checkProjectFiles,
+    checkToolchain,
+    downloadFile,
+    extractArchive,
+    getAllFiles
+} from './utils.js';

--- a/task.md
+++ b/task.md
@@ -13,12 +13,16 @@ To package and export sourcemaps and types for lsp-cli:
 
 - [x] Create library entry point src/lib.ts that exports core classes and types (LanguageClient, ServerManager, Logger, all types from types.ts)
 - [x] Update tsconfig.json to enable declaration file generation with `"declaration": true` and `"declarationMap": true`
-- [ ] Modify build script to use TypeScript compiler (tsc) for generating declaration files alongside esbuild
-- [ ] Update esbuild command to generate sourcemaps with `--sourcemap` flag
-- [ ] Create separate build outputs: dist/cli.js for CLI and dist/lib.js for library usage
+- [x] Modify build script to use TypeScript compiler (tsc) for generating declaration files alongside esbuild
+- [x] Update esbuild command to generate sourcemaps with `--sourcemap` flag
+- [x] Create separate build outputs: dist/cli.js for CLI and dist/lib.js for library usage
 - [ ] Update package.json with proper exports field for dual CLI/library usage and types field pointing to dist/lib.d.ts
 - [ ] Add dist/**/*.d.ts and dist/**/*.js.map to files array in package.json to include in published package
 - [ ] Test that types and sourcemaps work correctly when importing the package
 
 ## Notes
-[Implementation notes]
+- Decided to use TypeScript compiler output directly for library files instead of bundling with esbuild
+  - This provides better tree-shaking for consumers
+  - Allows importing individual modules
+  - More idiomatic for library distribution
+- CLI is still bundled for single-file executable distribution

--- a/task.md
+++ b/task.md
@@ -1,18 +1,24 @@
 # Package and Export Sourcemaps and Types
-**Status:** Refining
-**Agent PID:** 99516
+**Status:** InProgress
+**Agent PID:** 6325
 
 ## Original Todo
 also package and export the sourcemaps and types so other apps can reuse them
 
 ## Description
-[what we're building]
+We need to enhance the lsp-cli build process to generate and export TypeScript declaration files (.d.ts) and sourcemaps (.js.map) so that other applications can use lsp-cli as a library with full type support and debugging capabilities. This involves modifying the build configuration to generate these artifacts and updating package.json to properly expose them. Additionally, we'll create a library entry point separate from the CLI to expose the core functionality programmatically.
 
 ## Implementation Plan
-[how we are building it]
-- [ ] Code change with location(s) if applicable
-- [ ] Automated test: ...
-- [ ] User test: ...
+To package and export sourcemaps and types for lsp-cli:
+
+- [ ] Create library entry point src/lib.ts that exports core classes and types (LanguageClient, ServerManager, Logger, all types from types.ts)
+- [ ] Update tsconfig.json to enable declaration file generation with `"declaration": true` and `"declarationMap": true`
+- [ ] Modify build script to use TypeScript compiler (tsc) for generating declaration files alongside esbuild
+- [ ] Update esbuild command to generate sourcemaps with `--sourcemap` flag
+- [ ] Create separate build outputs: dist/cli.js for CLI and dist/lib.js for library usage
+- [ ] Update package.json with proper exports field for dual CLI/library usage and types field pointing to dist/lib.d.ts
+- [ ] Add dist/**/*.d.ts and dist/**/*.js.map to files array in package.json to include in published package
+- [ ] Test that types and sourcemaps work correctly when importing the package
 
 ## Notes
 [Implementation notes]

--- a/task.md
+++ b/task.md
@@ -12,7 +12,7 @@ We need to enhance the lsp-cli build process to generate and export TypeScript d
 To package and export sourcemaps and types for lsp-cli:
 
 - [x] Create library entry point src/lib.ts that exports core classes and types (LanguageClient, ServerManager, Logger, all types from types.ts)
-- [ ] Update tsconfig.json to enable declaration file generation with `"declaration": true` and `"declarationMap": true`
+- [x] Update tsconfig.json to enable declaration file generation with `"declaration": true` and `"declarationMap": true`
 - [ ] Modify build script to use TypeScript compiler (tsc) for generating declaration files alongside esbuild
 - [ ] Update esbuild command to generate sourcemaps with `--sourcemap` flag
 - [ ] Create separate build outputs: dist/cli.js for CLI and dist/lib.js for library usage

--- a/task.md
+++ b/task.md
@@ -11,7 +11,7 @@ We need to enhance the lsp-cli build process to generate and export TypeScript d
 ## Implementation Plan
 To package and export sourcemaps and types for lsp-cli:
 
-- [ ] Create library entry point src/lib.ts that exports core classes and types (LanguageClient, ServerManager, Logger, all types from types.ts)
+- [x] Create library entry point src/lib.ts that exports core classes and types (LanguageClient, ServerManager, Logger, all types from types.ts)
 - [ ] Update tsconfig.json to enable declaration file generation with `"declaration": true` and `"declarationMap": true`
 - [ ] Modify build script to use TypeScript compiler (tsc) for generating declaration files alongside esbuild
 - [ ] Update esbuild command to generate sourcemaps with `--sourcemap` flag

--- a/task.md
+++ b/task.md
@@ -1,6 +1,6 @@
 # Package and Export Sourcemaps and Types
 **Status:** InProgress
-**Agent PID:** 6325
+**Agent PID:** 17496
 
 ## Original Todo
 also package and export the sourcemaps and types so other apps can reuse them
@@ -16,9 +16,9 @@ To package and export sourcemaps and types for lsp-cli:
 - [x] Modify build script to use TypeScript compiler (tsc) for generating declaration files alongside esbuild
 - [x] Update esbuild command to generate sourcemaps with `--sourcemap` flag
 - [x] Create separate build outputs: dist/cli.js for CLI and dist/lib.js for library usage
-- [ ] Update package.json with proper exports field for dual CLI/library usage and types field pointing to dist/lib.d.ts
-- [ ] Add dist/**/*.d.ts and dist/**/*.js.map to files array in package.json to include in published package
-- [ ] Test that types and sourcemaps work correctly when importing the package
+- [x] Update package.json with proper exports field for dual CLI/library usage and types field pointing to dist/lib.d.ts
+- [x] Add dist/**/*.d.ts and dist/**/*.js.map to files array in package.json to include in published package
+- [x] Test that types and sourcemaps work correctly when importing the package
 
 ## Notes
 - Decided to use TypeScript compiler output directly for library files instead of bundling with esbuild

--- a/task.md
+++ b/task.md
@@ -1,5 +1,5 @@
 # Package and Export Sourcemaps and Types
-**Status:** InProgress
+**Status:** AwaitingCommit
 **Agent PID:** 17496
 
 ## Original Todo

--- a/task.md
+++ b/task.md
@@ -1,0 +1,18 @@
+# Package and Export Sourcemaps and Types
+**Status:** Refining
+**Agent PID:** 99516
+
+## Original Todo
+also package and export the sourcemaps and types so other apps can reuse them
+
+## Description
+[what we're building]
+
+## Implementation Plan
+[how we are building it]
+- [ ] Code change with location(s) if applicable
+- [ ] Automated test: ...
+- [ ] User test: ...
+
+## Notes
+[Implementation notes]

--- a/todos/done/20250714-152206-package-sourcemaps-types.md
+++ b/todos/done/20250714-152206-package-sourcemaps-types.md
@@ -1,5 +1,5 @@
 # Package and Export Sourcemaps and Types
-**Status:** AwaitingCommit
+**Status:** Done
 **Agent PID:** 17496
 
 ## Original Todo

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,10 @@
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "resolveJsonModule": true,
-        "moduleResolution": "node"
+        "moduleResolution": "node",
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true
     },
     "include": ["src/**/*"],
     "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- Added TypeScript declaration files and sourcemaps to the build output
- Created library entry point (src/lib.ts) for programmatic usage
- Configured package.json with proper exports field for dual CLI/library usage

## Test plan
- [x] Build generates .d.ts and .js.map files
- [x] Types work when importing the package
- [x] All existing tests pass
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.ai/code)