### PR TITLE
feat: Add CLI wrapper tools (lsp-cli-jq and lsp-cli-file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,68 @@ npx tsx src/index.ts /path/to/java/project java types.json -v
 lsp-cli --llm
 ```
 
+## lsp-cli-jq Wrapper
+
+A convenience wrapper that automatically analyzes the current directory and runs jq queries on the results.
+
+### Usage
+```bash
+lsp-cli-jq <language> <jq_query>
+```
+
+### Examples
+```bash
+# Find all class names in a TypeScript project
+lsp-cli-jq typescript '.symbols[] | select(.kind == "class") | .name'
+
+# Get file locations of all methods in a Java project
+lsp-cli-jq java '.symbols[] | .. | objects | select(.kind == "method") | "\(.file):\(.range.start.line + 1)"'
+
+# Find functions with TODO comments
+lsp-cli-jq typescript '.symbols[] | .. | objects | select(.comments[]? | contains("TODO")) | .name'
+```
+
+The wrapper automatically:
+- Analyzes the current working directory
+- Generates temporary JSON files with cleanup
+- Forwards jq queries to the analysis results
+
+Use `lsp-cli-jq --help` for more information and comprehensive examples.
+
+## lsp-cli-file Wrapper
+
+A convenience wrapper for analyzing single source files with formatted output. Built on top of `lsp-cli-jq`.
+
+### Usage
+```bash
+lsp-cli-file <language> <sourcefile>
+```
+
+### Example
+```bash
+# Analyze a TypeScript file
+lsp-cli-file typescript src/MyClass.ts
+
+# Output format:
+# ClassName (class):
+#     10-50: "export class ClassName {"
+#       doc: Class documentation
+#     15-20: "constructor() {"
+#       doc: Constructor documentation
+#       # Implementation comments
+#     22-25: "public myMethod(): void {"
+#       doc: Method documentation
+#       # Method implementation comments
+```
+
+The wrapper:
+- Uses `lsp-cli-jq` internally to analyze the current directory
+- Filters results to show only the specified file
+- Formats output with line numbers, documentation, and inline comments
+- Shows class structure with methods and constructors
+
+**Note:** Both `lsp-cli-file` and `lsp-cli-jq` are included when you install lsp-cli globally.
+
 ## Output
 
 The tool outputs JSON with all symbols found in the codebase:

--- a/bin/lsp-cli-file
+++ b/bin/lsp-cli-file
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#!/bin/bash
+
+# Check if required arguments are provided
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 language sourcefile"
+  exit 1
+fi
+
+# Validate file path
+FILEPATH=$(readlink -f "$2" 2>/dev/null)
+if [ $? -ne 0 ] || [ ! -f "$FILEPATH" ]; then
+  echo "Error: Invalid or inaccessible file path: $2"
+  exit 1
+fi
+
+export FILEPATH
+
+lsp-cli-jq "$1" '.symbols[] | select(.file == env.FILEPATH) | "\(.name) (\(.kind)):\n    \(.range.start.line + 1)-\(.range.end.line + 1): \"\(.preview // .name)\"" + (if .documentation then "\n      doc: " + (.documentation | gsub("\n"; " | ")) else "" end) + (if .comments then "\n      # " + (.comments | join(" | ")) else "" end) + (if .kind == "class" then "\n" + ([(.children[]? | select(.kind == "constructor") | "    \(.range.start.line + 1)-\(.range.end.line + 1): \"\(.preview // "constructor()")\""), (.children[]? | select(.kind == "method") | "    \(.range.start.line + 1)-\(.range.end.line + 1): \"\(.preview)\"" + (if .documentation then "\n      doc: " + (.documentation | gsub("\n"; " | ")) else "" end) + (if .comments then "\n      # " + (.comments | join(" | ")) else "" end))] | sort_by(split(":")[0] | ltrimstr("    ") | split("-")[0] | tonumber) | join("\n")) else "" end)' | jq -r | sed 's/\\n/\n/g'
+
+
+# lsp-cli-jq language '.symbols[] | select(.file == "/ABSOLUTE/PATH/TO/FILENAME") | "\(.name) (\(.kind)):\n    \(.range.start.line + 1)-\(.range.end.line + 1): \"\(.preview // .name)\"" + (if .documentation then "\n      doc: " + (.documentation | gsub("\n"; " | ")) else "" end) + (if .comments then "\n      # " + (.comments | join(" | ")) else "" end) + (if .kind == "class" then "\n" + ([(.children[]? | select(.kind == "constructor") | "    \(.range.start.line + 1)-\(.range.end.line + 1): \"\(.preview // "constructor()")\""), (.children[]? | select(.kind == "method") | "    \(.range.start.line + 1)-\(.range.end.line + 1): \"\(.preview)\"" + (if .documentation then "\n      doc: " + (.documentation | gsub("\n"; " | ")) else "" end) + (if .comments then "\n      # " + (.comments | join(" | ")) else "" end))] | sort_by(split(":")[0] | ltrimstr("    ") | split("-")[0] | tonumber) | join("\n")) else "" end)' | jq -r | sed 's/\\n/\n/g'

--- a/bin/lsp-cli-jq
+++ b/bin/lsp-cli-jq
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# lsp-cli-jq - Wrapper script for lsp-cli + jq analysis
+# Automatically analyzes current directory and runs jq queries
+
+set -e
+
+# Show help
+if [[ $# -eq 0 || "$1" == "--help" || "$1" == "-h" ]]; then
+    echo "lsp-cli-jq - Wrapper script for lsp-cli that automatically analyzes the current directory"
+    echo
+    echo "Usage: lsp-cli-jq <language> <jq_query>"
+    echo "       lsp-cli-jq --help"
+    echo
+    echo "Arguments:"
+    echo "  language   Programming language (java, cpp, c, csharp, haxe, typescript, dart)"
+    echo "  jq_query   JQ query to run on the analysis results"
+    echo
+    echo "Options:"
+    echo "  --help, -h Show this help message and full lsp-cli documentation"
+    echo
+    echo "Examples:"
+    echo "  lsp-cli-jq typescript '.symbols[] | select(.kind == \"class\") | .name'"
+    echo "  lsp-cli-jq java '.symbols[] | select(.name == \"MyClass\") | .file'"
+    echo
+    echo "The script generates a temporary JSON file and cleans it up automatically."
+    echo
+    echo "Full lsp-cli documentation:"
+    echo "----------------------------------------"
+    lsp-cli --llm
+    exit 0
+fi
+
+# Check arguments
+if [[ $# -ne 2 ]]; then
+    echo "Error: Expected 2 arguments, got $#" >&2
+    echo "Usage: lsp-cli-jq <language> <jq_query>" >&2
+    echo "Use --help for more information" >&2
+    exit 1
+fi
+
+language="$1"
+jq_query="$2"
+
+# Generate temp filename from current working directory
+cwd_absolute=$(pwd)
+cwd_sanitized=$(echo "$cwd_absolute" | sed 's|^/||' | tr '/' '-')
+temp_file="/tmp/${cwd_sanitized}-lsp-cli.json"
+
+# Cleanup function
+cleanup() {
+    [[ -f "$temp_file" ]] && rm -f "$temp_file"
+}
+trap cleanup EXIT
+
+# Run lsp-cli (suppress stdout, show stderr for errors)
+if ! lsp-cli . "$language" "$temp_file" >/dev/null; then
+    echo "Error: lsp-cli analysis failed" >&2
+    exit 1
+fi
+
+# Run jq query
+jq "$jq_query" "$temp_file"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "main": "dist/lib.js",
     "types": "dist/lib.d.ts",
     "bin": {
-        "lsp-cli": "dist/cli.js"
+        "lsp-cli": "dist/cli.js",
+        "lsp-cli-jq": "dist/lsp-cli-jq",
+        "lsp-cli-file": "dist/lsp-cli-file"
     },
     "exports": {
         ".": {
@@ -24,11 +26,13 @@
         "dist/**/*.d.ts",
         "dist/**/*.js.map",
         "dist/**/*.d.ts.map",
-        "dist/llms.md"
+        "dist/llms.md",
+        "dist/lsp-cli-jq",
+        "dist/lsp-cli-file"
     ],
     "scripts": {
         "start": "tsx src/index.ts",
-        "build": "rm -rf dist && mkdir -p dist && tsc && esbuild src/index.ts --bundle --platform=node --target=node18 --outfile=dist/cli.js --sourcemap --banner:js='#!/usr/bin/env node' && chmod +x dist/cli.js && cp llms.md dist/",
+        "build": "rm -rf dist && mkdir -p dist && tsc && esbuild src/index.ts --bundle --platform=node --target=node18 --outfile=dist/cli.js --sourcemap --banner:js='#!/usr/bin/env node' && chmod +x dist/cli.js && cp llms.md dist/ && cp bin/lsp-cli-jq bin/lsp-cli-file dist/ && chmod +x dist/lsp-cli-jq dist/lsp-cli-file",
         "typecheck": "tsc --noEmit",
         "lint": "biome check --write . --error-on-warnings",
         "format": "biome format --write .",


### PR DESCRIPTION
## Summary
Add two convenience wrapper scripts to improve developer experience and streamline common workflows.

## Changes

### lsp-cli-jq (Base Wrapper)
- **Purpose**: One-command analysis + jq query of current directory
- **Features**:
  - Automatic temp file generation and cleanup
  - Forwards jq queries directly to analysis results
  - Comprehensive help and usage examples
  - 63 lines of clean, focused code

### lsp-cli-file (Convenience Wrapper)
- **Purpose**: Single-file analysis with formatted output
- **Features**:
  - Wrapper around lsp-cli-jq with pre-configured query
  - Shows classes with methods, line numbers, documentation, and comments
  - 22 lines - simple and maintainable
  - **Dependency**: Calls lsp-cli-jq internally

### Packaging
- Added both scripts to `package.json` bin entries
- Updated build script to copy wrappers to dist/
- Added to files array for npm packaging
- Both scripts properly executable and packaged

## Workflow Improvement

**Before (2 commands):**
```bash
lsp-cli . typescript output.json
jq '.symbols[] | select(.kind == "class")' output.json
```

**After with lsp-cli-jq (1 command):**
```bash
lsp-cli-jq typescript '.symbols[] | select(.kind == "class")'
```

**After with lsp-cli-file (formatted single-file analysis):**
```bash
lsp-cli-file typescript src/MyClass.ts
```

## Testing
- ✅ `npm run build` successfully packages both scripts
- ✅ lsp-cli-jq executes with various jq queries
- ✅ lsp-cli-file properly calls lsp-cli-jq and formats output
- ✅ Both scripts included in dist/ after build

## Dependencies
Based on upstream/main (v0.1.3)

## Note
Both scripts work together as a dependency chain: `lsp-cli → lsp-cli-jq → lsp-cli-file`